### PR TITLE
Add minor fixes

### DIFF
--- a/src/models/issueGenerator.ts
+++ b/src/models/issueGenerator.ts
@@ -107,8 +107,10 @@ ${this.proposalInfo.strategy}
   }
 
   public async createIssue() {
+    const OWNER = process.env.GITHUB_OWNER || ''
+    const REPO = process.env.GITHUB_REPO || ''
     const response = await fetch(
-      'https://api.github.com/search/issues?q=repo:GeneralMagicio/aragon-tao-voting'
+      `https://api.github.com/search/issues?q=repo:${OWNER}/${REPO}`
     )
     const repoIssues = await response.json()
     const issueNumber = (repoIssues.total_count + 1).toString()
@@ -116,7 +118,7 @@ ${this.proposalInfo.strategy}
     const imageUrl = await this.uploadImageImgur()
 
     const reponse = await fetch(
-      'https://api.github.com/repos/GeneralMagicio/aragon-tao-voting/issues',
+      `https://api.github.com/repos/${OWNER}/${REPO}/issues`,
       {
         method: 'POST',
         headers: {

--- a/src/models/taoVoting.ts
+++ b/src/models/taoVoting.ts
@@ -53,11 +53,11 @@ export class TaoVoting {
     const disputableVoting = {
       proposalDeposit: {
         token: this.disputableVoting.proposalDeposit,
-        valueUsd: this.disputableVoting.proposalDeposit * tokenPrice,
+        valueUsd: Number((this.disputableVoting.proposalDeposit * tokenPrice).toFixed(2)),
       },
       challengeDeposit: {
         token: this.disputableVoting.challengeDeposit,
-        valueUsd: this.disputableVoting.challengeDeposit * tokenPrice,
+        valueUsd: Number((this.disputableVoting.challengeDeposit * tokenPrice).toFixed(2)),
       },
       setlementPeriod: this.disputableVoting.settlementPeriod,
     }


### PR DESCRIPTION
This PR adds the following fixes:
- Enables the configuration of the used GitHub repo for voting with the `GITHUB_OWNER` and `GITHUB_REPO` env variables
- Rounds the Disputable Voting values to two decimal places